### PR TITLE
refactor: replace engine terminology with game maker phrasing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -96,7 +96,7 @@ export default defineConfig({
               link: "/events/",
             },
             {
-              label: "Game Maker changelog",
+              label: "Changelog",
               link: "/changelog/",
             },
             {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title:
-        "Pixel Stories, the modern no-code game engine for story-driven games",
+        "Pixel Stories, the modern no-code game maker for story-driven games",
       logo: {
         light: "./src/assets/logo-light.svg",
         dark: "./src/assets/logo-dark.svg",
@@ -96,7 +96,7 @@ export default defineConfig({
               link: "/events/",
             },
             {
-              label: "Engine changelog",
+              label: "Game Maker changelog",
               link: "/changelog/",
             },
             {

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -13,8 +13,8 @@ import FooterLogo from "./FooterLogo.astro";
     <div
       class="flex flex-wrap md:flex-nowrap justify-between grow max-w-[500px] gap-x-14 gap-y-6"
     >
-      <!-- Engine -->
-      <FooterColumn name="Engine">
+      <!-- Game Maker -->
+      <FooterColumn name="Game Maker">
         <FooterLink href="/overview">Documentation</FooterLink>
         <FooterLink href="/guides">Guides</FooterLink>
         <FooterLink href="/pricing">Pricing</FooterLink>

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -20,7 +20,7 @@ const recentPosts = sortedPosts.slice(0, 4);
       <div class="flex flex-wrap gap-2 items-stretch">
         <div class="flex-1 h-full min-w-[200px]">
           <LinkCard
-            title="Engine Docs"
+            title="Game Maker Docs"
             description="See our quick guide on getting started!"
             href="/getting-started"
           />
@@ -28,7 +28,7 @@ const recentPosts = sortedPosts.slice(0, 4);
         <div class="flex-1 h-full min-w-[200px]">
           <LinkCard
             title="Get Started Tutorial"
-            description="Get familiar with the engine with our tutorial."
+            description="Get familiar with the game maker with our tutorial."
             href="/tutorials/basic"
           />
         </div>

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -20,7 +20,7 @@ const recentPosts = sortedPosts.slice(0, 4);
       <div class="flex flex-wrap gap-2 items-stretch">
         <div class="flex-1 h-full min-w-[200px]">
           <LinkCard
-            title="Game Maker Docs"
+            title="Pixel Stories Docs"
             description="See our quick guide on getting started!"
             href="/getting-started"
           />
@@ -28,7 +28,7 @@ const recentPosts = sortedPosts.slice(0, 4);
         <div class="flex-1 h-full min-w-[200px]">
           <LinkCard
             title="Get Started Tutorial"
-            description="Get familiar with the game maker with our tutorial."
+            description="Get familiar with the editor with our tutorial."
             href="/tutorials/basic"
           />
         </div>

--- a/src/components/PricingColumn.astro
+++ b/src/components/PricingColumn.astro
@@ -84,7 +84,7 @@ const href = "https://app.pixelstories.io/editor?purchase";
           target="_blank"
           rel="noopener noreferrer"
         >
-          Launch engine
+          Open editor
         </a>
       )
     }

--- a/src/components/PricingFaq.astro
+++ b/src/components/PricingFaq.astro
@@ -4,14 +4,14 @@
   <br />
 
   <div>
-    <strong>Game Maker</strong>
+    <strong>Pixel Stories</strong>
   </div>
 
   <details>
     <summary>Do I need to know how to code?</summary>
     Nope! Pixel Stories is designed from the ground up to be a no-code game maker.
-    With the Pixel Stories game maker, you can easily build your captivating
-    and immersive story-driven game without the need of a technical background.
+    With the Pixel Stories game maker, you can easily build your captivating and
+    immersive story-driven game without the need of a technical background.
   </details>
 
   <details>

--- a/src/components/PricingFaq.astro
+++ b/src/components/PricingFaq.astro
@@ -4,13 +4,13 @@
   <br />
 
   <div>
-    <strong>Game Engine</strong>
+    <strong>Game Maker</strong>
   </div>
 
   <details>
     <summary>Do I need to know how to code?</summary>
-    Nope! The Pixel Stories Engine is designed from the ground up to be a no-code
-    engine. With the Pixel Stories Engine, you can easily build your captivating
+    Nope! Pixel Stories is designed from the ground up to be a no-code game maker.
+    With the Pixel Stories game maker, you can easily build your captivating
     and immersive story-driven game without the need of a technical background.
   </details>
 
@@ -34,7 +34,7 @@
   </div>
 
   <details>
-    <summary>How do I learn the Pixel Stories engine?</summary>
+    <summary>How do I learn the Pixel Stories game maker?</summary>
     Check out our in depth tutorials on the
     <a href="/tutorials/project-setup">Pixel Stories Docs </a>
     ! We also offer

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -46,7 +46,7 @@ const plans = [
       class="text-base font-medium border rounded-lg p-1 px-3 bg-gradient-to-r
       text-black from-indigo-200 via-purple-200 to-pink-200"
     >
-      The Pixel Stories game maker
+      Pixel Stories
     </p>
     <p class="text-2xl text-center">
       Make your <span class="italic">story-driven</span> game for desktop, mobile,

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -7,7 +7,7 @@ const plans = [
     description: "Create your game today!",
     price: "$0",
     points: [
-      "Access to all engine features",
+      "Access to all game maker features",
       "Unlimited events",
       "Unlimited custom assets",
       "Desktop export",
@@ -46,7 +46,7 @@ const plans = [
       class="text-base font-medium border rounded-lg p-1 px-3 bg-gradient-to-r
       text-black from-indigo-200 via-purple-200 to-pink-200"
     >
-      The Pixel Stories Engine
+      The Pixel Stories game maker
     </p>
     <p class="text-2xl text-center">
       Make your <span class="italic">story-driven</span> game for desktop, mobile,

--- a/src/content/blog/animation-import-flow-update.md
+++ b/src/content/blog/animation-import-flow-update.md
@@ -4,7 +4,7 @@ date: 2025-03-11
 excerpt: Animation configuration now inherits default settings from character definitions, reducing redundancy and enabling idle animations.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Less Redundancy in Animation Import Flow

--- a/src/content/blog/better-dialog-screen-customization.md
+++ b/src/content/blog/better-dialog-screen-customization.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/better-dialog-screen-customization.png
   alt: Dialog screen customization preview
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Better Dialog Screen Customization

--- a/src/content/blog/choice-event-upgrade.md
+++ b/src/content/blog/choice-event-upgrade.md
@@ -4,7 +4,7 @@ date: 2025-05-01
 excerpt: This update improves polish and usability across the board. More intuitive defaults, better error handling, and cleaner editing.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ### Smoother Setup, Smarter Defaults, and a Cleaner Editor

--- a/src/content/blog/introducing-code-event.md
+++ b/src/content/blog/introducing-code-event.md
@@ -4,7 +4,7 @@ date: 2025-04-11
 excerpt: With the new Run Code event, you can now write custom JavaScript to control game objects, the camera, scene behavior, and more, right from within your events.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ### Run Custom Code at Any Point in Your Game
@@ -15,7 +15,7 @@ Inspired by the flexibility of command-line tools and frameworks like Phaser (wh
 
 This new event lets you inject your own JavaScript directly into your game. That means full access to the Phaser `game` object, open-ended control over game objects, camera, scene behavior, and much more. Want to shake the camera? Add a screen effect? Spawn enemies based on dynamic logic? Now you can.
 
-Instead of building a growing library of plugins that risk conflicts and complexity, we’re giving you the power to customize behavior in small, focused pieces, similar to other game engines.
+Instead of building a growing library of plugins that risk conflicts and complexity, we’re giving you the power to customize behavior in small, focused pieces, similar to other game makers.
 
 Whether you’re an experienced developer or just starting to learn, this unlocks a whole new layer of creativity in your game.
 

--- a/src/content/blog/misc-user-experience-fixes.md
+++ b/src/content/blog/misc-user-experience-fixes.md
@@ -4,7 +4,7 @@ date: 2025-02-26
 excerpt: Improvements in routing, side panel usability, project switching, and editor behavior for a more smoother experience.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Misc User Experience Improvements

--- a/src/content/blog/more-map-editor-enhancements.md
+++ b/src/content/blog/more-map-editor-enhancements.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/map-editor-enhancement.png
   alt: Map editor enhancement preview
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # More Map Editor Enhancements

--- a/src/content/blog/new-open-source-assets.md
+++ b/src/content/blog/new-open-source-assets.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/new-open-source-assets-1.png
   alt: Asset management update preview
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # New Free and Open Source Assets!

--- a/src/content/blog/release-0.12.0.md
+++ b/src/content/blog/release-0.12.0.md
@@ -4,7 +4,7 @@ date: 2025-05-25
 excerpt: This update brings two big changes to help you build games more reliably and make it easier for new creators to get started.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ## Guest Mode: Start Creating Instantly

--- a/src/content/blog/release-0.13.0.md
+++ b/src/content/blog/release-0.13.0.md
@@ -4,7 +4,7 @@ date: 2025-06-16
 excerpt: The old map editor UI had some glaring design issues. This update brings a fresh look and feel to the editor to make map creation better than before!
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ## Major Map Editor Overhaul

--- a/src/content/blog/release-0.14.0.md
+++ b/src/content/blog/release-0.14.0.md
@@ -4,7 +4,7 @@ date: 2025-07-02
 excerpt: This update ships a revamped asset library and starter asset pack, plus improvements to tilesets and editor usability.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ## Better Base Asset Pack to get Started

--- a/src/content/blog/release-0.15.0.md
+++ b/src/content/blog/release-0.15.0.md
@@ -4,7 +4,7 @@ date: 2025-07-08
 excerpt: This update adds a full inventory system with UI and events, plus important fixes to the editor and game.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ## Introducing Inventory System

--- a/src/content/blog/release-0.16.0.md
+++ b/src/content/blog/release-0.16.0.md
@@ -4,7 +4,7 @@ date: 2025-07-17
 excerpt: This release introduces new NPC chase and patrol mechanics along with a way to tie event triggers to an NPC's position.
 author: Truman
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 ## New NPC Chase Player and Patrol Events

--- a/src/content/blog/show-image-set-character-anim.md
+++ b/src/content/blog/show-image-set-character-anim.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/new-events.png
   alt: Preview of new events for showing images and setting character animations
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # New Events: Show Image and Set Character Animation

--- a/src/content/blog/smooth-map-transitions-event-group-cleanup.md
+++ b/src/content/blog/smooth-map-transitions-event-group-cleanup.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/smooth-map-transitions.png
   alt: Preview of smooth map transition effect
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Smooth Map Transitions and Event Group Cleanup

--- a/src/content/blog/standalone-game-export.md
+++ b/src/content/blog/standalone-game-export.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/web-export-standalone-builds.png
   alt: Screenshot showcasing the new web export and standalone build features
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Standalone Game Web Export
@@ -18,7 +18,7 @@ You can now export your games directly to HTML, CSS, and JavaScript, making them
 
 ## Changelog with Development History
 
-With this standalone game export, we realized that we need to provide a good sense of versioning for your games and which version of game engine it was made with. If the game engine has a breaking change update, your game will still work with the engine version it was exported with. Right now there is only one release of the game container, so the export will come with that version. In the future, we will add an export release selector so you can have the granular control over your game export. You can find [the changelog here](/changelog/).
+With this standalone game export, we realized that we need to provide a good sense of versioning for your games and which version of the game maker it was made with. If the game maker has a breaking change update, your game will still work with the game maker version it was exported with. Right now there is only one release of the game container, so the export will come with that version. In the future, we will add an export release selector so you can have the granular control over your game export. You can find [the changelog here](/changelog/).
 
 ### Changelog
 
@@ -26,4 +26,4 @@ With this standalone game export, we realized that we need to provide a good sen
 
 - [Editor] Export games to web platforms using HTML, CSS, and JavaScript.
 - [Misc] Support for creating standalone game builds.
-- [Changelog] Comprehensive development history of the Pixel Stories Engine.
+- [Changelog] Comprehensive development history of the Pixel Stories game maker.

--- a/src/content/blog/terrain-update.md
+++ b/src/content/blog/terrain-update.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/new-terrain-thumbnail.png
   alt: A terrain in Pixel Stories
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # Improved Terrain Creation and Map Editing

--- a/src/content/blog/true-game-window-sizing.md
+++ b/src/content/blog/true-game-window-sizing.md
@@ -7,7 +7,7 @@ cover:
   image: ../../assets/images/true-game-window-sizing-1.png
   alt: Game scaling and responsiveness update preview
 tags:
-  - ENGINE UPDATE
+  - GAME MAKER UPDATE
 ---
 
 # True Game Window Sizing!

--- a/src/content/blog/welcome-to-blog.md
+++ b/src/content/blog/welcome-to-blog.md
@@ -7,11 +7,11 @@ tags:
   - NEWS
 ---
 
-Today I'm adding a blog to Pixel Stories! The purpose of this blog is to keep our community updated on the latest developments as we build the engine.
+Today I'm adding a blog to Pixel Stories! The purpose of this blog is to keep our community updated on the latest developments as we build the game maker.
 
 ### Why Have a Blog?
 
-Pixel Stories started as passion project which has now evolved into a game engine built for story-driven games. I've been working on it for the past year and a half, continously improving the engine and adding features. About a week ago, I realized that there was no way for someone to see how the engine has progressed since it's conception.
+Pixel Stories started as passion project which has now evolved into a game maker built for story-driven games. I've been working on it for the past year and a half, continuously improving the game maker and adding features. About a week ago, I realized that there was no way for someone to see how the game maker has progressed since it's conception.
 
 That's why I added this blog to the website. I plan to use this blog as a medium to share exciting new
 features as well as showcasing work in progress and keeping a change log.

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-title: Pixel Stories Game Maker Changelog
+title: Pixel Stories Changelog
 description: Find specific releases and changelogs for the game maker.
 ---
 

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
-title: Pixel Stories Engine Changelog
-description: Find specific releases and changelogs for the engine.
+title: Pixel Stories Game Maker Changelog
+description: Find specific releases and changelogs for the game maker.
 ---
 
 ## 0.16.0
@@ -146,7 +146,7 @@ Added
 
 - [Editor] Add game export for web HTML/CSS/JS
 - [Misc] Add standalone game build
-- [Changelog] Add a rough history of development in the Pixel Stories Engine
+- [Changelog] Add a rough history of development in the Pixel Stories game maker
 
 ---
 
@@ -350,7 +350,7 @@ Choices event and UI Upgrade
 
 **April 10, 2024**
 
-- Core engine features
+- Core game maker features
 
 ---
 
@@ -358,4 +358,4 @@ Choices event and UI Upgrade
 
 **July 21, 2023**
 
-Begin development of Pixel Stories Engine
+Begin development of Pixel Stories game maker

--- a/src/content/docs/features/game-assets.md
+++ b/src/content/docs/features/game-assets.md
@@ -5,7 +5,7 @@ description: How game asset management works in Pixel Stories
 
 Game Assets in Pixel Stories is designed to help users effectively manage all types of game assets. Game assets include images, animations, actors, sounds/music, and variables.
 
-Uploading assets into Pixel Stories is designed to be simple. Each asset is individually uploaded into the game engine and always replaceable.
+Uploading assets into Pixel Stories is designed to be simple. Each asset is individually uploaded into the game maker and always replaceable.
 
 ## Map Terrains
 
@@ -93,7 +93,7 @@ To import animations, they must be in the format of single row sprite strips. Su
 
 If you asset came in a spritesheet grid, you can use a spritesheet editing tool like [EZGif Spritesheet cutter](https://ezgif.com/sprite-cutter) to slice the spritesheet into rows.
 
-The engine does not currently support animations that come in a GIF format. To use a gif, [EZGif gif to spritesheet](https://ezgif.com/gif-to-sprite) can convert to a sprite strip.
+The game maker does not currently support animations that come in a GIF format. To use a gif, [EZGif gif to spritesheet](https://ezgif.com/gif-to-sprite) can convert to a sprite strip.
 
 # Animation Configuration
 
@@ -113,7 +113,7 @@ Audio and images can also be imported into your game in Pixel Stories.
 
 ### File Types
 
-Since our game engine is web-based, we can automatically support a wide range of file types. The following are what's supported.
+Since our game maker is web-based, we can automatically support a wide range of file types. The following are what's supported.
 
 **Audio:**
 

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -5,17 +5,17 @@ description: Getting started with Pixel Stories
 
 import { Steps } from "@astrojs/starlight/components";
 
-The goal of this guide is to show you all the core functionality in the Pixel Stories Engine. After this quick guide, you’ll be primed with all the basic knowledge you need to explore more as well as start creating your first story game!
+The goal of this guide is to show you all the core functionality in the Pixel Stories game maker. After this quick guide, you’ll be primed with all the basic knowledge you need to explore more as well as start creating your first story game!
 
 We’ll be building a simple game from scratch. In the tutorial, we go through setting up the project and game assets, building a game map, and adding game interactions with events.
 
 ## Project Setup
 
-First let’s make a project in the game engine.
+First let’s make a project in the game maker.
 
 <Steps>
 
-1.  Open the [Pixel Stories Engine](https://app.pixelstories.io/).
+1.  Open the [Pixel Stories editor](https://app.pixelstories.io/).
 2.  Log in or create an account.
 3.  Create a new blank project.
 
@@ -23,7 +23,7 @@ First let’s make a project in the game engine.
 
 ## Game Assets
 
-Now that you have a project, we need to add some game assets to start building our map. For now we’ll use the default assets the engine provides.
+Now that you have a project, we need to add some game assets to start building our map. For now we’ll use the default assets the game maker provides.
 
 <Steps>
 
@@ -174,7 +174,7 @@ Share your game by copying the link found in the `Share game` button at the top 
 
 Now you're primed with all the basic knowledge to start building a story game, we recommend to start building out your idea right away and learn as you go!
 
-Below are some guides and concepts which go in more depth on how to use the Pixel Stories Engine for special mechanics and features.
+Below are some guides and concepts which go in more depth on how to use the Pixel Stories game maker for special mechanics and features.
 
 - [Moving your player between maps](/guides/moving-your-player-between-maps)
 - [Making a quest](/guides/fetch-quest)

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: Pixel Stories empowers you to create captivating narrative adventur
 template: splash
 hero:
   title: <p> A Game Maker for <span class="bg-gradient-to-r from-pink-600 via-pink-600 to-pink-700 bg-clip-text text-transparent text-nowrap"> Story-driven </span> Games </p>
-  tagline: Pixel Stories is a web-based no-code game maker for making top down story-driven games.
+  tagline: Pixel Stories is a web-based no-code game creation tool for making top down story-driven games.
   image:
     alt: A glittering, interested, happy ghost
     file: ../../assets/logo-outline.svg

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Pixel Stories
-description: Pixel Stories empowers you to create captivating narrative adventures with an intuitive, no-code game engine.
+description: Pixel Stories empowers you to create captivating narrative adventures with an intuitive, no-code game maker.
 template: splash
 hero:
-  title: <p> A Game Engine For <span class="bg-gradient-to-r from-pink-600 via-pink-600 to-pink-700 bg-clip-text text-transparent text-nowrap"> Story-driven </span> Games </p>
-  tagline: Pixel Stories is a web based no-code game engine for making top down story-driven games.
+  title: <p> A Game Maker for <span class="bg-gradient-to-r from-pink-600 via-pink-600 to-pink-700 bg-clip-text text-transparent text-nowrap"> Story-driven </span> Games </p>
+  tagline: Pixel Stories is a web-based no-code game maker for making top down story-driven games.
   image:
     alt: A glittering, interested, happy ghost
     file: ../../assets/logo-outline.svg

--- a/src/content/docs/overview.md
+++ b/src/content/docs/overview.md
@@ -1,37 +1,37 @@
 ---
 title: What is Pixel Stories?
-description: An overview of the Pixel Stories game engine.
+description: An overview of the Pixel Stories game maker.
 ---
 
-Pixel Stories is a game engine built specifically for making 2D top down story-driven games.
+Pixel Stories is a game maker built specifically for creating 2D top down story-driven games.
 
-Our game engine is quick to learn and easy to work with. This let’s you to focus on creating unique and immersive stories without being overwhelmed by the complexities in game development with a general engine.
+Our game creation tool is quick to learn and easy to work with. This lets you focus on creating unique and immersive stories without being overwhelmed by the complexities in game development with a general tool.
 
 ## The Core of Pixel Stories
 
-- **Story-driven game** engine designed for creating story-driven, top‑down games.
+- **Story-driven game** maker designed for top‑down games.
 - **Events system** allows you to build dynamic and interactive gameplay.
 - **Dialog System** let’s you write branching dialogs.
 - **Map editor** makes map creation easy with auto tile terrains and map objects.
 - **Custom assets** support importing your own art, music, and sounds.
 - **Cross‑platform** support let’s you to share your game for desktop, mobile, and web.
 
-## Pixel Stories vs. Other Engines
+## Pixel Stories vs. Other Game Makers
 
-Unlike other general game engines that demand a lot of coding to get started, Pixel Stories offers a straightforward game making workflow.
+Unlike other general game makers that demand a lot of coding to get started, Pixel Stories offers a straightforward game making workflow.
 
 It’s made for 2D top down story-driven games, so it comes with all the necessary tools for that purpose. That includes an events system, dialogue editor, map editor, and default assets to help you get started. Additionally, you can easily import your own custom assets and customize different features of your game, so it has its own unique style rather than a cookie-cutter look.
 
-We designed our game engine with accessibility in mind so that anyone can create their own game. Being web‑based, it only requires a modern browser, and its cross‑platform support ensure your game is can be shared on desktop, mobile, or anywhere on the web!
+We designed our game maker with accessibility in mind so that anyone can create their own game. Being web‑based, it only requires a modern browser, and its cross‑platform support ensure your game can be shared on desktop, mobile, or anywhere on the web!
 
-Note for those coming from RPG Maker: We don’t have abritrary restrictions on game resolution, tile size or sprite animation formats! You also have full control over map editing layers. To avoid reliance on community plugins, we've tried to integrate all the essential features for making story-driven games directly into the engine. If you think a feature is missing, feel free to [make a feature suggestion](https://forms.gle/76x3G1mkUQpKvbG7A)!
+Note for those coming from RPG Maker: We don’t have abritrary restrictions on game resolution, tile size or sprite animation formats! You also have full control over map editing layers. To avoid reliance on community plugins, we've tried to integrate all the essential features for making story-driven games directly into the game maker. If you think a feature is missing, feel free to [make a feature suggestion](https://forms.gle/76x3G1mkUQpKvbG7A)!
 
 ## Early Access Beta
 
-The Pixel Stories game engine is in a late-stage beta, so you might encounter some bugs in making your game.
+The Pixel Stories game maker is in a late-stage beta, so you might encounter some bugs in making your game.
 
 Please report any bugs, feedback, or suggestions you have through our [feedback form](https://forms.gle/76x3G1mkUQpKvbG7A). Thank you and we appreciate your support as an early adopter!
 
 ## Community
 
-Ask questions, get support in using the engine, share your projects, or give feedback on our [official Discord server](https://discord.gg/XN9EaUh26g).
+Ask questions, get support in using the game maker, share your projects, or give feedback on our [official Discord server](https://discord.gg/XN9EaUh26g).

--- a/src/content/docs/overview.md
+++ b/src/content/docs/overview.md
@@ -3,7 +3,7 @@ title: What is Pixel Stories?
 description: An overview of the Pixel Stories game maker.
 ---
 
-Pixel Stories is a game maker built specifically for creating 2D top down story-driven games.
+Pixel Stories is a game creation tool built specifically for creating 2D top down story-driven games.
 
 Our game creation tool is quick to learn and easy to work with. This lets you focus on creating unique and immersive stories without being overwhelmed by the complexities in game development with a general tool.
 

--- a/src/content/docs/pricing.mdx
+++ b/src/content/docs/pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Pixel Stories
-description: Discover pricing plans for Pixel Stories, the modern game engine for creating immersive, story-driven games. Our pricing include one-time payments designed to meet the needs of indie developers and professional studios alike.
+description: Discover pricing plans for Pixel Stories, the modern game maker for creating immersive, story-driven games. Our pricing include one-time payments designed to meet the needs of indie developers and professional studios alike.
 template: splash
 editUrl: false
 hero:

--- a/src/content/docs/tutorials/conditional-branching.mdx
+++ b/src/content/docs/tutorials/conditional-branching.mdx
@@ -47,7 +47,7 @@ Now, we’ll create two event groups: one for finding the key and one for openin
 
 </Steps>
 
-Note, we had to add the `Remove event group` event after it was added because the engine only allows you to remove event groups which have been added into the map.
+Note, we had to add the `Remove event group` event after it was added because the game maker only allows you to remove event groups which have been added into the map.
 
 ### Open Chest Event Group
 

--- a/src/content/docs/tutorials/exporting.mdx
+++ b/src/content/docs/tutorials/exporting.mdx
@@ -5,7 +5,7 @@ description: A beginners guide to Pixel Stories
 
 import { Steps } from "@astrojs/starlight/components";
 
-Here is how to export your game made in the Pixel Stories Engine so you can share it with others and let them experience your creation.
+Here is how to export your game made in the Pixel Stories game maker so you can share it with others and let them experience your creation.
 
 ## Sharing Your Game
 
@@ -31,7 +31,7 @@ Windows, Mac, and Linux application exports are currently in development and wil
 
 Thanks for going through the tutorials! Join us on [Discord](https://discord.gg/XN9EaUh26g) if you'd like to get more help or give feedback/suggestions.
 
-Learn more about the core features of the engine below.
+Learn more about the core features of the game maker below.
 
 - [The events system](/features/events-system)
 - [Map editor](/features/map-editor)

--- a/src/content/docs/tutorials/project-setup.mdx
+++ b/src/content/docs/tutorials/project-setup.mdx
@@ -5,12 +5,12 @@ description: A beginners guide to Pixel Stories
 
 import { Steps } from "@astrojs/starlight/components";
 
-In the following tutorials, we'll be going through all the core features in the Pixel Stories engine. By the end of this tutorial, you will be exposed to all the tools needed to start creating your story-driven game immediately!
+In the following tutorials, we'll be going through all the core features in the Pixel Stories game maker. By the end of this tutorial, you will be exposed to all the tools needed to start creating your story-driven game immediately!
 
 To follow along:
 
 - <a href="https://app.pixelstories.io/editor" target="_blank">
-    Open the game engine
+    Open the editor
   </a>
 
 - <a
@@ -22,7 +22,7 @@ To follow along:
 
 ## Project Set-up
 
-To get started, first we have to launch the game engine and create a new story.
+To get started, first we have to open the editor and create a new story.
 
 <Steps>
 

--- a/src/overrides/ThemeSelect.astro
+++ b/src/overrides/ThemeSelect.astro
@@ -20,7 +20,7 @@ import type { Props } from "@astrojs/starlight/props";
     target="_blank"
     rel="noopener noreferrer"
   >
-    Launch engine
+    Open editor
     <Icon name="external" size="1.25rem" />
   </a>
 </div>


### PR DESCRIPTION
## Summary
- replace user-facing "engine" references with "game maker", "editor", or "game creation tool" across docs and UI
- update navigation and meta copy to highlight the Pixel Stories game maker
- retitle blog update tags to "GAME MAKER UPDATE"

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aab7dabcf88332bf06efc6aac7e16f