### PR TITLE
Add release 0.18.0 blog post

### DIFF
--- a/src/content/blog/release-0_18_0.md
+++ b/src/content/blog/release-0_18_0.md
@@ -1,0 +1,37 @@
+---
+title: Immersive Audio Controls and Touch-Ready Adventures
+date: 2025-09-26
+excerpt: Release 0.18.0 introduces in-game audio settings, PS Maker sound management, and touch controls so players can enjoy Pixel Stories anywhere.
+author: Truman
+tags:
+  - GAME MAKER UPDATE
+---
+
+## Fine-tune every playthrough
+
+Pixel Stories 0.18.0 gives both creators and players more ways to tailor their stories. Open the new in-game settings panel to balance music and sound effects, manage soundtracks directly inside PS Maker, and bring your adventures to mobile with touch-friendly controls.
+
+### Adjust audio without leaving the story
+
+Players can now open an in-story settings menu to tweak music and sound volumes on the fly. The panel also collects other presentation toggles, making it easy to customize how a story looks and sounds without interrupting the moment.
+
+### Manage music and sound in PS Maker
+
+Audio joins the list of game components in PS Maker. Creators can upload, organize, and preview tracks alongside the rest of their project assets, keeping every scene’s soundtrack ready for playtesting.
+
+### Touch-first play on phones and tablets
+
+This release brings a full touch control layout for mobile players. Swipe and tap to move your character, trigger actions with an on-screen button, and optionally surface keyboard hints so anyone can jump into the adventure.
+
+### Full changelog
+
+- [Docs] Changed release docs md file naming scheme to use underscore instead of dot for release version number.
+- [Editor] Fixed dark theme still existing when browser has default dark theme.
+- [Editor] Redirect directly to projects page in /editor when user lands on app's root path.
+- [Dialog box] Set default font in dialog box to be cursive system font.
+- [Editor] Renamed game assets to game components for better representation.
+- [Audio] Added audio into game components list, including uploading and previewing audio.
+- [Game] Added game settings for players to adjust music/sound levels, enable touch controls, and show keyboard controls
+- [Game] Added touch controls for moving character and touch action button
+- [Game] Added crash guard to suggest for user to refresh page
+- [Game] Added default aspect ratio game resolution options

--- a/src/content/blog/release-0_18_0.md
+++ b/src/content/blog/release-0_18_0.md
@@ -1,27 +1,25 @@
 ---
-title: Immersive Audio Controls and Touch-Ready Adventures
-date: 2025-09-26
-excerpt: Release 0.18.0 introduces in-game audio settings, PS Maker sound management, and touch controls so players can enjoy Pixel Stories anywhere.
+title: Audio Events, Touch Controls for Mobile, and General Fixes!
+date: 2025-09-27
+excerpt: Release 0.18.0 introduces an in-game settings menu, PS Maker audio management, and touch controls so players play on mobile.
 author: Truman
 tags:
   - GAME MAKER UPDATE
 ---
 
-## Fine-tune every playthrough
+Pixel Stories 0.18.0 gives both creators and players more ways to play their stories. Open the new in-game settings panel to see sound volume settings and controls, manage audio tracks directly inside PS Maker, and bring your adventures to mobile with touch-friendly controls.
 
-Pixel Stories 0.18.0 gives both creators and players more ways to tailor their stories. Open the new in-game settings panel to balance music and sound effects, manage soundtracks directly inside PS Maker, and bring your adventures to mobile with touch-friendly controls.
-
-### Adjust audio without leaving the story
+### Game Settings Menu
 
 Players can now open an in-story settings menu to tweak music and sound volumes on the fly. The panel also collects other presentation toggles, making it easy to customize how a story looks and sounds without interrupting the moment.
 
-### Manage music and sound in PS Maker
+### Manage Audio in PS Maker
 
 Audio joins the list of game components in PS Maker. Creators can upload, organize, and preview tracks alongside the rest of their project assets, keeping every scene’s soundtrack ready for playtesting.
 
-### Touch-first play on phones and tablets
+### Touch Controls on Phones and Tablets
 
-This release brings a full touch control layout for mobile players. Swipe and tap to move your character, trigger actions with an on-screen button, and optionally surface keyboard hints so anyone can jump into the adventure.
+This release brings touch controls for mobile players. You can move your character and trigger interactions with the action button. Creators who are making stories will have them automatically be mobile ready.
 
 ### Full changelog
 
@@ -35,3 +33,5 @@ This release brings a full touch control layout for mobile players. Swipe and ta
 - [Game] Added touch controls for moving character and touch action button
 - [Game] Added crash guard to suggest for user to refresh page
 - [Game] Added default aspect ratio game resolution options
+- [Dialog] Fixed game events stuck when dialog event is empty
+- [Game] Added a simple NPC preview for spawn NPC event

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -3,6 +3,53 @@ title: Pixel Stories Changelog
 description: Find specific releases and changelogs for the game maker.
 ---
 
+## 0.18.0
+
+**September 27, 2025** ([Release notes](https://pixelstories.io/blog/release-0_18_0))
+
+- [Docs] Changed release docs md file naming scheme to use underscore instead of dot for release version number.
+- [Editor] Fixed dark theme still existing when browser has default dark theme.
+- [Editor] Redirect directly to projects page in /editor when user lands on app's root path.
+- [Dialog box] Set default font in dialog box to be cursive system font.
+- [Editor] Renamed game assets to game components for better representation.
+- [Audio] Added audio into game components list, including uploading and previewing audio.
+- [Game] Added game settings for players to adjust music/sound levels, enable touch controls, and show keyboard controls
+- [Game] Added touch controls for moving character and touch action button
+- [Game] Added crash guard to suggest for user to refresh page
+- [Game] Added default aspect ratio game resolution options
+- [Dialog] Fixed game events stuck when dialog event is empty
+- [Game] Added a simple NPC preview for spawn NPC event
+
+## 0.17.0
+
+**September 11, 2025** ([Release notes](https://pixelstories.io/blog/release-0.17.0))
+
+- [Editor] Fixed restart game resetting editor mode and map editing mode
+- [Map editor] Fixed switch to rectangle/circle for tileset if its a single tile
+- [Editor] Fixed discrepancy between character and NPC event names
+- [Map editor, tileset] Fixed tiles selection going out of bounds of tileset and breaking tile stamping
+- [Map editor] Fixed deleting map layer not actually deleting map layer
+- [Map editor] Fixed reordering map layers not reordering
+- [Map editor] Fixed broken create new maps
+- [Map editor] Fixed deleting map leading to broken state
+- [Map editor] Added right click for draw tools to switch to erase tool counterpart
+- [Events editor] Separated event groups and map events (On load events) to their own tabs
+- [Events editor] Revamped add game event modal
+- [Show image] Simplified show image event configuration and removed unnecessary features
+- [Game variables] Fixed bug where inventory variables interfering with user variables
+- [Events editor] Removed unfinished image, music, and sound management, and music/sound events
+- [Events editor] Fixed bug where add event group to map is did not add instance Id
+- [Dialog event] Fixed awkward space present after [pb] and [r] tags in dialog rendering. Also adjusted default text size to be smaller.
+- [Chase event] Fixed overlapping player touch/collision activated events with chase end touch events and event group following NPC touch event. Priorty is given to chase event touch, event group touch is disabled until NPC is done chasing and finishes on chase end events.
+- [Add event group event] Added trigger area size for event group triggers.
+- [Game] Fixed collision detection between player, event group triggers, and NPCs to be based on rectangle overlap instead of distance.
+- [Characters] Renamed all character related titles to use NPC instead
+- [NPCs] Fixed back button loop after deleting an animation
+- [NPCs] Moved player out of NPC list, into own asset
+- [Game] Fixed game restart not keeping active map after restarting
+- [Asset library] Fixed asset library access for guest users
+- [Game] Fixed long loading times for projects with a lot of assets during game restart
+
 ## 0.16.0
 
 **July 17, 2025** ([Release notes](https://pixelstories.io/blog/release-0.16.0))


### PR DESCRIPTION
## Summary
- add a new release 0.18.0 blog article detailing the in-game settings menu, PS Maker audio workflow, and touch-first play experience
- capture the full 0.18.0 changelog for quick reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6de64c6b883328cc8883abc4def4e